### PR TITLE
Corrige overflow del botón Reiniciar y padding del home

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,9 +161,12 @@
         <div class="pill">Nivel <span id="level">1</span></div>
         <div class="pill big">Puntaje: <span id="score" class="accent">0</span> / <span id="target">200</span></div>
         <div class="pill" title="Vidas"><span id="lives">❤️❤️❤️</span></div>
-        <div style="display:flex; gap:8px; justify-content:flex-end; align-items:center; flex-wrap:wrap;">
+        <div class="hud-actions">
           <div class="pill" title="Tiempo restante">⏱️ <span id="time">45</span>s</div>
-          <button id="restart">Reiniciar</button>
+          <button id="restart" type="button">
+            <span aria-hidden="true">🔄</span>
+            <span>Reiniciar</span>
+          </button>
         </div>
       </div>
 

--- a/styles.css
+++ b/styles.css
@@ -25,9 +25,10 @@ body {
   min-height: 100vh;
   background: #f7dce9;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  padding: 24px;
+  justify-content: flex-start;
+  padding: clamp(24px, 6vh, 64px) clamp(20px, 6vw, 60px);
   font-family: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans";
   color: var(--text);
 }
@@ -446,20 +447,42 @@ body {
   color: var(--accent);
 }
 
+.hud-actions {
+  justify-self: end;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
 .hud button {
   justify-self: end;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   border: 0;
-  background: var(--accent);
-  color: white;
+  background: linear-gradient(180deg, #ff8fc0, #ff5aa4);
+  color: #fff;
   font-weight: 800;
-  padding: 10px 14px;
+  font-size: clamp(15px, 2.1vw, 18px);
+  padding: 10px 18px;
   border-radius: 999px;
   cursor: pointer;
-  box-shadow: 0 8px 18px rgba(245, 154, 194, 0.45);
+  box-shadow: 0 12px 24px rgba(245, 154, 194, 0.4);
+  max-width: 100%;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
 }
 
 .hud button:hover {
-  filter: brightness(1.05);
+  transform: translateY(-1px);
+  box-shadow: 0 16px 26px rgba(245, 154, 194, 0.35);
+}
+
+.hud button:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 2px;
 }
 
 .powers {
@@ -623,8 +646,8 @@ body {
 
 @media (max-width: 720px) {
   body {
-    align-items: flex-start;
-    justify-content: flex-start;
+    align-items: stretch;
+    padding: clamp(20px, 6vh, 40px) clamp(16px, 6vw, 28px);
   }
 
   :root {
@@ -649,8 +672,15 @@ body {
     row-gap: 12px;
   }
 
+  .hud-actions {
+    grid-column: 1 / -1;
+    justify-self: stretch;
+    justify-content: space-between;
+  }
+
   .hud button {
     justify-self: stretch;
+    flex: 1 1 160px;
   }
 
   .powers {
@@ -660,7 +690,7 @@ body {
 
 @media (max-width: 520px) {
   body {
-    padding: 16px 12px;
+    padding: max(18px, env(safe-area-inset-top, 0px)) 12px 20px;
   }
 
   .screen.active::before {
@@ -686,6 +716,20 @@ body {
 
   .hud {
     padding: 12px;
+  }
+
+  .hud-actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .hud-actions .pill {
+    text-align: center;
+  }
+
+  .hud button {
+    width: 100%;
   }
 
   .builder-controls {


### PR DESCRIPTION
## Summary
- Ajusta el layout principal para que la pantalla de inicio tenga espacio superior consistente en diferentes tamaños de pantalla.
- Reestructura el HUD del juego creando un contenedor dedicado y estiliza el botón Reiniciar con icono y comportamiento responsive.

## Testing
- Manual verification in local browser


------
https://chatgpt.com/codex/tasks/task_e_68e0ac99d35083339355683539f2d654