### PR TITLE
Fix restart button sizing and board layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -461,27 +461,31 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  border: 0;
-  background: linear-gradient(180deg, #ff8fc0, #ff5aa4);
-  color: #fff;
+  gap: 6px;
+  border: 1px solid rgba(91, 75, 89, 0.08);
+  background: #fff;
+  color: var(--text);
   font-weight: 800;
-  font-size: clamp(15px, 2.1vw, 18px);
-  padding: 10px 18px;
-  border-radius: 999px;
+  font-size: clamp(13px, 1.8vw, 16px);
+  padding: 8px 14px;
+  border-radius: 12px;
   cursor: pointer;
-  box-shadow: 0 12px 24px rgba(245, 154, 194, 0.4);
+  box-shadow: 0 6px 14px rgba(91, 75, 89, 0.18);
   max-width: 100%;
   transition: transform 0.18s ease, box-shadow 0.18s ease;
 }
 
+.hud button span[aria-hidden="true"] {
+  font-size: 16px;
+}
+
 .hud button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 16px 26px rgba(245, 154, 194, 0.35);
+  box-shadow: 0 10px 20px rgba(91, 75, 89, 0.2);
 }
 
 .hud button:focus-visible {
-  outline: 3px solid rgba(255, 255, 255, 0.8);
+  outline: 3px solid rgba(245, 154, 194, 0.65);
   outline-offset: 2px;
 }
 


### PR DESCRIPTION
## Summary
- ensure tile metrics are recalculated once the game screen is visible so pieces are positioned correctly
- reuse a shared helper when (re)starting levels to keep sizing updates consistent
- restyle the HUD restart control to a compact pill design

## Testing
- Manual verification: start a game and confirm the board fills and restart control renders correctly

------
https://chatgpt.com/codex/tasks/task_e_68e0b08d42488333b01118e4a008056b